### PR TITLE
Fix for Safety plugin

### DIFF
--- a/hxargs/Args.hx
+++ b/hxargs/Args.hx
@@ -66,7 +66,7 @@ class Args {
 				case _: cmds;
 			}
 			var cmds = switch(cmds.expr) {
-				case EArrayDecl(el):
+				case EArrayDecl(el) | EParenthesis({expr: ECheckType({expr: EArrayDecl(el), pos: _}, _), pos: _}):
 					for (e in el) {
 						switch(e.expr) {
 							case EConst(CString(_)):


### PR DESCRIPTION
Recentry I tried to use Safety plugin (https://github.com/RealyUniqueName/Safety), and it doesn't work well with hxargs. Following code:

```haxe
hxargs.Args.generate([
    @doc('Desired size, 1 by default')
    ["-s", "--size"] => (size : String) -> {
        // ...
    },
    // ...
]);
```

Throws `"[commands] or command expected"` error. While it may be Safety plugin fault, it easier to fix this on hxargs side.

And it still compatible for Haxe without Safety plugin.

What do you think?